### PR TITLE
refactor(location): move non-essential scripts to head and defer

### DIFF
--- a/Location.html
+++ b/Location.html
@@ -10,6 +10,16 @@
     <script src="https://polyfill.io/v3/polyfill.min.js?features=default"></script>
     <link rel="icon" type="image/png" sizes="32x32" href="Assets/favicon-32x32.png">
 
+    <script defer
+      src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCs0eoO8UcMZKu8iqRhgJP3-XhTIUdGEVA&callback=initMap"></script>
+    <!-- Bootstrap -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/css/bootstrap.min.css" rel="preload"
+      integrity="sha384-gH2yIJqKdNHPEq0n4Mqa/HGKIhSkIHeL5AyhkYV8i59U5AR6csBvApHHNl/vI1Bx"
+      crossorigin="anonymous" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <!-- Script tag support for Typescript -->
+    <script defer src="https://rawgit.com/Microsoft/TypeScript/master/lib/typescriptServices.js"></script>
+    <script defer src="https://rawgit.com/basarat/typescript-script/master/transpiler.js"></script>
+    <script defer type="text/typescript" src="script.ts"></script>
 </head>
 <header>
     <nav class="navbar navbar-expand-lg navbar-light bg-light">
@@ -34,28 +44,6 @@
 </nav> 
 </header>
 <body>
-    
-    <div id="map"></div>
-    
-
-
-
-
-
-
-
-
-  
-
-
-<script async src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCs0eoO8UcMZKu8iqRhgJP3-XhTIUdGEVA&callback=initMap"></script>
-<!-- Bootstrap -->
-<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-gH2yIJqKdNHPEq0n4Mqa/HGKIhSkIHeL5AyhkYV8i59U5AR6csBvApHHNl/vI1Bx" crossorigin="anonymous">
-<!-- Script tag support for Typescript -->
-<script src="https://rawgit.com/Microsoft/TypeScript/master/lib/typescriptServices.js"></script>
-<script src="https://rawgit.com/basarat/typescript-script/master/transpiler.js"></script>
-<script type="text/typescript" src="script.ts"></script>
-
-
+  <div id="map"></div>
 </body>
 </html>


### PR DESCRIPTION
Move scripts and links at the bottom of the body to the head.
This uses `defer` and `preload`.
These do not process assets until the browser is idle.
This is the same as your original code but optimised by the browser.
